### PR TITLE
Moving the special case for selling the entire supply after the case of CRR=100

### DIFF
--- a/solidity/contracts/BancorFormula.sol
+++ b/solidity/contracts/BancorFormula.sol
@@ -72,10 +72,6 @@ contract BancorFormula is IBancorFormula, SafeMath {
         if (_sellAmount == 0)
             return 0;
 
-        // special case for selling the entire supply
-        if (_sellAmount == _supply)
-            return _reserveBalance;
-
         uint256 baseN = safeSub(_supply, _sellAmount);
         uint256 temp1;
         uint256 temp2;
@@ -86,6 +82,10 @@ contract BancorFormula is IBancorFormula, SafeMath {
             temp2 = safeMul(_reserveBalance, baseN);
             return safeSub(temp1, temp2) / _supply;
         }
+
+        // special case for selling the entire supply
+        if (_sellAmount == _supply)
+            return _reserveBalance;
 
         var (resN, resD) = power(_supply, baseN, 100, _reserveRatio);
         temp1 = safeMul(_reserveBalance, resN);


### PR DESCRIPTION
The case of selling the entire supply is a very special case and will likely not occur very often (because it essentially means killing the whole token). However, the CRR=100 is much more common. It seems unnecessary for all contracts to pay gas to check for this condition, as the same result can be achieved by moving this down. It can be verified that the case of selling the entire supply works fine with the existing case of CRR=100. 