### PR TITLE
Add an assertion to safeMul

### DIFF
--- a/solidity/python/Formula/Power/__init__.py
+++ b/solidity/python/Formula/Power/__init__.py
@@ -202,4 +202,5 @@ def fixedExpUnsafe(_x):
 
 
 def safeMul(x,y):
+    assert(x * y < (1 << 256))
     return x * y


### PR DESCRIPTION
Make sure that the product is less than 256-bit long.