### PR TITLE
Improve accuracy and performance

### DIFF
--- a/solidity/contracts/BancorFormula.sol
+++ b/solidity/contracts/BancorFormula.sol
@@ -326,7 +326,7 @@ contract BancorFormula is IBancorFormula, SafeMath {
             return 1;
         if (100000 * baseN <= 738905 * baseD) // baseN / baseD < e^2
             return 2;
-        if (baseN <= 8 * baseD)               // baseN / baseD <= 2^3 < e^3
+        if (baseN <= 20 * baseD)              // baseN / baseD < e^3
             return 3;
 
         return floorLog2(baseN/baseD);


### PR DESCRIPTION
If base <= 20, then the upper bound of ln(base) is 3.
This will improve the accuracy (and performance) for the cases of 9 <= base <= 20.