### PR TITLE
Improve accuracy and performance

### DIFF
--- a/solidity/python/Formula/Power/__init__.py
+++ b/solidity/python/Formula/Power/__init__.py
@@ -203,7 +203,7 @@ def lnUpperBound(baseN,baseD):
         return 1
     if 100000*baseN <= 738905*baseD: # baseN/baseD < e^2
         return 2
-    if baseN <= 8*baseD:             # baseN/baseD <= 2^3 < e^3
+    if baseN <= 20*baseD:            # baseN/baseD < e^3
         return 3
     return floorLog2(baseN/baseD)
 


### PR DESCRIPTION
If base <= 20, then the upper bound of ln(base) is 3.
This will improve the accuracy (and performance) for the cases of 9 <= base <= 20.