### PR TITLE
Improve accuracy and performance

### DIFF
--- a/solidity/python/Formula/Power/__init__.py
+++ b/solidity/python/Formula/Power/__init__.py
@@ -199,12 +199,13 @@ def getBestPrecision(_baseN, _baseD, _expN, _expD):
 
 def lnUpperBound(baseN,baseD):
     assert(baseN > baseD)
-    if 100000*baseN <= 271828*baseD: # baseN/baseD < e^1
-        return 1
-    if 100000*baseN <= 738905*baseD: # baseN/baseD < e^2
-        return 2
-    if baseN <= 8*baseD:             # baseN/baseD <= 2^3 < e^3
-        return 3
+    scaled_baseN = baseN * 100000;
+    if (scaled_baseN <= baseD *  271828): # baseN / baseD < e^1
+        return 1;
+    if (scaled_baseN <= baseD *  738905): # baseN / baseD < e^2
+        return 2;
+    if (scaled_baseN <= baseD * 2008553): # baseN / baseD < e^3
+        return 3;
     return floorLog2(baseN/baseD)
 
 


### PR DESCRIPTION
If base <= ~20, then the upper bound of ln(base) is 3.
So the case of returning 3 can be extended from base <= 8 to base <= ~20.
This improves:
- The accuracy for 16 <= base <= ~20, which in the old version returned 4 instead of 3.
- The performance for 9 <= base <= ~20, which in the old version were calculated via floorLog2.