### PR TITLE
Calculate the max factor for increasing MaxExp by

### DIFF
--- a/solidity/python/constants/PrintMaxExpPerPrecision.py
+++ b/solidity/python/constants/PrintMaxExpPerPrecision.py
@@ -69,4 +69,45 @@ for i in range(len(values)/NUM_OF_VALUES_PER_ROW):
     for j in range(NUM_OF_VALUES_PER_ROW):
         items.append('0x{:x}'.format(values[i*NUM_OF_VALUES_PER_ROW+j]))
     print '    '+''.join([formatString.format(item) for item in items])
-print ']'
+print ']\n'
+
+
+lo = 1
+hi = 1 << 256
+while lo+1 < hi:
+    mid = (lo+hi)/2
+    try:
+        for precision in range(32,64,2):
+            maxExp = values[32]
+            for p in range (32,precision,2):
+                maxExp = safeMul(maxExp,mid)/100000000000000000
+                fixedExpUnsafe(maxExp,precision)
+        lo = mid
+        mid = (lo+hi)/2
+    except Exception,error:
+        hi = mid
+        mid = (lo+hi)/2
+try:
+    for precision in range(32,64,2):
+        maxExp = values[32]
+        for p in range (32,precision,2):
+            maxExp = safeMul(maxExp,hi)/100000000000000000
+            fixedExpUnsafe(maxExp,precision)
+    maxFactor = hi
+except Exception,error:
+    for precision in range(32,64,2):
+        maxExp = values[32]
+        for p in range (32,precision,2):
+            maxExp = safeMul(maxExp,lo)/100000000000000000
+            fixedExpUnsafe(maxExp,precision)
+    maxFactor = lo
+
+
+print 'maxFactor = ',maxFactor
+formatString = '{:s}{:d}{:s}{:d}{:s}'.format('Precision = {:3d} | Theoretical Max Exp = {:',maxLen,'s} | Practical Max Exp = {:',maxLen,'s}')
+for precision in range(32,64,2):
+    maxExp = values[32]
+    for p in range (32,precision,2):
+        maxExp = safeMul(maxExp,maxFactor)/100000000000000000
+        fixedExpUnsafe(maxExp,precision)
+    print formatString.format(precision,'0x{:x}'.format(values[precision]),'0x{:x}'.format(maxExp))


### PR DESCRIPTION
The maximum value that we can use when calling function fixedExpUnsafe depends on precision.
For our minimum precision of 32, it is 0x386bfdba29.
For each additional bit, it increases by approximately 1.9.
Our precision may be a value between 32 and 64, in multiples of 2 (i.e., 32, 34, 36, ..., 64).
So in order to calculate the maximum value that we can use when calling function fixedExpUnsafe, we start from 0x386bfdba29 and multiply it by 1.9^2 an appropriate amount of times, i.e., "(precision-32)/2" times.
Since we cannot use non-integers, we should multiply by 19^2 and divide by 10^2.
But there is a better approximation, since this "1.9" factor in fact extends beyond one decimal digit.

In order to find the best factor, added in this commit is a binary search for all possible precision values, yielding:
367765941410234761/100000000000000000.