### PR TITLE
Minor accuracy improvement

### DIFF
--- a/solidity/contracts/BancorFormula.sol
+++ b/solidity/contracts/BancorFormula.sol
@@ -233,7 +233,7 @@ contract BancorFormula is IBancorFormula, SafeMath {
         - MaxFixedExp(precision) = MAX_FIXED_EXP_32 * 3.61^(precision/2-16)
         Since we cannot use non-integers, we do MAX_FIXED_EXP_32 * 361^(precision/2-16) / 100^(precision/2-16).
         But there is a better approximation, because this "1.9" factor in fact extends beyond a single decimal digit.
-        So instead, we use 367765941410234761 / 100000000000000000, which yields maximum values quite close to real ones:
+        So instead, we use 0xeb5ec5975959c565 / 0x4000000000000000, which yields maximum values quite close to real ones:
         maxExpArray = {
             -------------------,-------------------,-------------------,-------------------,
             -------------------,-------------------,-------------------,-------------------,
@@ -249,14 +249,14 @@ contract BancorFormula is IBancorFormula, SafeMath {
             0x2214d10d0112e    ,-------------------,0x7d56e7677738e    ,-------------------,
             0x1ccf4b44bb20d0   ,-------------------,0x69f3d1c9210d27   ,-------------------,
             0x185a82b87b5b294  ,-------------------,0x5990681d95d4371  ,-------------------,
-            0x14962dee9dbd672a ,-------------------,0x4bb5ecca961fb9b8 ,-------------------,
-            0x116701e6ab096705a,-------------------,0x3fffffffffffe6599,-------------------,
+            0x14962dee9dbd672b ,-------------------,0x4bb5ecca961fb9bf ,-------------------,
+            0x116701e6ab0967080,-------------------,0x3fffffffffffe6652,-------------------,
         };
     */
     function fixedExp(uint256 _x, uint8 _precision) constant returns (uint256) {
         uint256 maxExp = MAX_FIXED_EXP_32;
         for (uint8 p = 32; p < _precision; p += 2)
-            maxExp = maxExp * 367765941410234761 / 100000000000000000;
+            maxExp = (maxExp * 0xeb5ec5975959c565) >> (64-2);
         
         assert(_x <= maxExp);
         return fixedExpUnsafe(_x, _precision);
@@ -383,7 +383,7 @@ contract BancorFormula is IBancorFormula, SafeMath {
         for (precision = 32; precision < 64; precision += 2) {
             if (maxExp < (maxVal << precision) / _expD)
                 break;
-            maxExp = maxExp * 367765941410234761 / 100000000000000000;
+            maxExp = (maxExp * 0xeb5ec5975959c565) >> (64-2);
         }
         if (precision == 32)
             return 32;


### PR DESCRIPTION
Use a larger base when computing the maximum factor with which we calculate the maximum value permitted for function fixedExpUnsafe.
So instead of the arbitrary base of 10^17, we use a base of 2^62, which gives the highest possible accuracy in computing the max-exp-per-precision.