### PR TITLE
Improve the natural log upper bound estimation

### DIFF
--- a/solidity/contracts/BancorFormula.sol
+++ b/solidity/contracts/BancorFormula.sol
@@ -182,7 +182,7 @@ contract BancorFormula is IBancorFormula, SafeMath {
         if (scaledBaseN <= _baseD * 2008553) // _baseN / _baseD < e^3 (floorLog2 will return 2 if _baseN / _baseD < 8)
             return 3;
 
-        return floorLog2(_baseN / _baseD);
+        return ((floorLog2((baseN-1)/baseD)+1)*0xb17217f7d1cf78+(1<<56)-1)>>56; // ceiling(ceiling(log2(base))*logE(2)))
     }
 
     /**


### PR DESCRIPTION
Instead of returning Floor(Log2(base)), return Ceiling(Ceiling(Log2(base))*LogE(2))).