### PR TITLE
Fix possible truncation of intermediate results

### DIFF
--- a/solidity/contracts/BancorFormula.sol
+++ b/solidity/contracts/BancorFormula.sol
@@ -171,7 +171,7 @@ contract BancorFormula is IBancorFormula, SafeMath {
         We cannot use floorLog2 when the input is smaller than 8.
         Complexity is O(log(input bit - length)).
     */
-    function lnUpperBound(uint256 _baseN, uint256 _baseD) constant returns (uint8) {
+    function lnUpperBound(uint256 _baseN, uint256 _baseD) constant returns (uint256) {
         assert(_baseN > _baseD);
 
         uint256 scaledBaseN = _baseN * 100000;
@@ -257,7 +257,7 @@ contract BancorFormula is IBancorFormula, SafeMath {
         Returns the largest integer smaller than or equal to the binary logarithm of the input.
         Complexity is O(log(input bit - length)).
     */
-    function floorLog2(uint256 _n) constant returns (uint8) {
+    function floorLog2(uint256 _n) constant returns (uint256) {
         uint8 t = 0;
         for (int k = 7; k >= 0; k--) {
             if (_n >= (uint256(1) << (1 << k))) {


### PR DESCRIPTION
Avoid truncation by returning uint256 instead of uint8 in functions lnUpperBound and floorLog2.