### PR TITLE
Update function lnUpperBound32

### DIFF
--- a/solidity/contracts/BancorFormula.sol
+++ b/solidity/contracts/BancorFormula.sol
@@ -167,8 +167,7 @@ contract BancorFormula is IBancorFormula, SafeMath {
         lnUpperBound32 
         Takes a rational number "baseN / baseD" as input.
         Returns an integer upper-bound of the natural logarithm of the input scaled by 2^32.
-        We do this by calculating "UpperBound(log2(baseN / baseD)) * Ceiling(ln(2) * 2^32)".
-        We calculate "UpperBound(log2(baseN / baseD))" as "Floor(log2((_baseN - 1) / _baseD)) + 1".
+        We do this by calculating "Ceiling(log2(baseN / baseD)) * Ceiling(ln(2) * 2^32)".
         For small values of "baseN / baseD", this sometimes yields a bad upper-bound approximation.
         We therefore cover these cases (and a few more) manually.
         Complexity is O(log(input bit-length)).
@@ -176,15 +175,15 @@ contract BancorFormula is IBancorFormula, SafeMath {
     function lnUpperBound32(uint256 _baseN, uint256 _baseD) constant returns (uint256) {
         assert(_baseN > _baseD);
 
-        uint256 scaledBaseN = _baseN * 100000;
-        if (scaledBaseN <= _baseD *  271828) // _baseN / _baseD < e^1 (floorLog2 will return 0 if _baseN / _baseD < 2)
+        uint256 scaledBaseN = _baseN << 32;
+        if (scaledBaseN <= _baseD *  0x2b7e15162) // _baseN / _baseD < e^1 (floorLog2 will return 0 if _baseN / _baseD < 2)
             return uint256(1) << 32;
-        if (scaledBaseN <= _baseD *  738905) // _baseN / _baseD < e^2 (floorLog2 will return 1 if _baseN / _baseD < 4)
+        if (scaledBaseN <= _baseD *  0x763992e35) // _baseN / _baseD < e^2 (floorLog2 will return 1 if _baseN / _baseD < 4)
             return uint256(2) << 32;
-        if (scaledBaseN <= _baseD * 2008553) // _baseN / _baseD < e^3 (floorLog2 will return 2 if _baseN / _baseD < 8)
+        if (scaledBaseN <= _baseD * 0x1415e5bf6f) // _baseN / _baseD < e^3 (floorLog2 will return 2 if _baseN / _baseD < 8)
             return uint256(3) << 32;
 
-        return (floorLog2((_baseN - 1) / _baseD) + 1) * 0xb17217f8;
+        return ceilLog2(_baseN, _baseD) * 0xb17217f8;
     }
 
     /**
@@ -248,6 +247,16 @@ contract BancorFormula is IBancorFormula, SafeMath {
         }
 
         return hi;
+    }
+
+    /**
+        ceilLog2
+        Takes a rational number "baseN / baseD" as input.
+        Returns the smallest integer larger than or equal to the binary logarithm of the input.
+        Complexity is O(log(input bit-length)).
+    */
+    function ceilLog2(uint256 _baseN, uint256 _baseD) constant returns (uint256) {
+        return floorLog2((_baseN - 1) / _baseD) + 1;
     }
 
     /**


### PR DESCRIPTION
1. Improve the accuracy of testing whether the input is smaller than e^1, e^2, e^3 or neither.
2. Add and use function ceilLog2 (this is essentially just for coding clarification).