### PR TITLE
Remove redundant asserts and update documentation

### DIFF
--- a/solidity/contracts/BancorFormula.sol
+++ b/solidity/contracts/BancorFormula.sol
@@ -141,24 +141,17 @@ contract BancorFormula is IBancorFormula, SafeMath {
     
     /**
         input range: 
-            - numerator: [1, uint256_max >> precision]    
-            - denominator: [1, uint256_max >> precision]
+            - numerator: [1, uint256_max / 2 ^ precision]    
+            - denominator: [1, numerator]
+            If numerator / denominator < 1 then ln(numerator / denominator) < 0
         output range:
-            [0, 0x9b43d4f8d6]
+            [0, ln(uint256_max) * 2 ^ precision]
 
         This method asserts outside of bounds
     */
     function ln(uint256 _numerator, uint256 _denominator, uint8 _precision) public constant returns (uint256) {
-        // denominator > numerator: less than one yields negative values. Unsupported
-        assert(_denominator <= _numerator);
-
-        // log(1) is the lowest we can go
-        assert(_denominator != 0 && _numerator != 0);
-
-        // Upper bits are scaled off by precision
-        uint256 MAX_VAL = ONE << (256 - _precision);
-        assert(_numerator < MAX_VAL);
-        assert(_denominator < MAX_VAL);
+        // validate input
+        assert(0 < _denominator && _denominator <= _numerator && _numerator < (ONE << (256 - _precision)));
 
         return fixedLoge( (_numerator << _precision) / _denominator, _precision);
     }


### PR DESCRIPTION
1. Remove the assertion of denominator < MAX_VAL:
    If denominator <= numerator and numerator < MAX_VAL, then obviously denominator < MAX_VAL.
2. Remove the assertion of numerator != 0:
    If denominator <= numerator and denominator != 0, then obviously numerator != 0.
3. Merge the remaining asserts into a single line which depicts the range of the input:
    0 < denominator <= numerator < 2 ^ (256 - _precision).
4. Update the documentation accordingly.