### PR TITLE
Prettify the Sale coverage test

### DIFF
--- a/solidity/python/CoverageSale.py
+++ b/solidity/python/CoverageSale.py
@@ -32,7 +32,7 @@ def Main():
     range_ratio   = [int(MINIMUM_VALUE_RATIO  *GROWTH_FACTOR_RATIO  **n) for n in range(int(log(MAXIMUM_VALUE_RATIO  ,GROWTH_FACTOR_RATIO  ))+1)]
     range_amount  = [int(MINIMUM_VALUE_AMOUNT *GROWTH_FACTOR_AMOUNT **n) for n in range(int(log(MAXIMUM_VALUE_AMOUNT ,GROWTH_FACTOR_AMOUNT ))+1)]
     
-    testNum = 0
+    testNum = 1
     numOfTests = len(range_supply)*len(range_reserve)*len(range_ratio)*len(range_amount)
     
     worstAbsoluteLoss = Record(range_supply[0],range_reserve[0],range_ratio[0],range_amount[0],0,0.0)
@@ -43,25 +43,24 @@ def Main():
             for         reserve in range_reserve:
                 for     ratio   in range_ratio  :
                     for amount  in range_amount :
+                        if amount <= supply:
+                            fixed,real = Test(supply,reserve,ratio,amount)
+                            if real < 0:
+                                pass # Transaction Invalid
+                            elif fixed < 0:
+                                pass # Transaction Failure
+                            elif real < fixed:
+                                print 'Implementation Error:',Record(supply,reserve,ratio,amount,fixed,real)
+                                return
+                            else: # 0 <= fixed <= real
+                                absoluteLoss = real-fixed
+                                relativeLoss = 1-fixed/real
+                                worstAbsoluteLoss.Update(supply,reserve,ratio,amount,fixed,real,absoluteLoss,relativeLoss)
+                                worstRelativeLoss.Update(supply,reserve,ratio,amount,fixed,real,relativeLoss,absoluteLoss)
+                        worstAbsoluteLossStr = 'worstAbsoluteLoss = {:.0f} (relativeLoss = {:.0f}%)'.format(worstAbsoluteLoss.major,worstAbsoluteLoss.minor*100)
+                        worstRelativeLossStr = 'worstRelativeLoss = {:.0f}% (absoluteLoss = {:.0f})'.format(worstRelativeLoss.major*100,worstRelativeLoss.minor)
+                        print 'Test {} out of {}: {}, {}'.format(testNum,numOfTests,worstAbsoluteLossStr,worstRelativeLossStr)
                         testNum += 1
-                        if amount > supply:
-                            continue
-                        fixed,real = Test(supply,reserve,ratio,amount)
-                        if real < 0:
-                            pass # Transaction Invalid
-                        elif fixed < 0:
-                            pass # Transaction Failure
-                        elif real < fixed:
-                            print 'Implementation Error:',Record(supply,reserve,ratio,amount,fixed,real)
-                            return
-                        else: # 0 <= fixed <= real
-                            absoluteLoss = real-fixed
-                            relativeLoss = 1-fixed/real
-                            worstAbsoluteLoss.Update(supply,reserve,ratio,amount,fixed,real,absoluteLoss,relativeLoss)
-                            worstRelativeLoss.Update(supply,reserve,ratio,amount,fixed,real,relativeLoss,absoluteLoss)
-                            worstAbsoluteLossStr = 'worstAbsoluteLoss = {:.0f} (relativeLoss = {:.0f}%)'.format(worstAbsoluteLoss.major,worstAbsoluteLoss.minor*100)
-                            worstRelativeLossStr = 'worstRelativeLoss = {:.0f}% (absoluteLoss = {:.0f})'.format(worstRelativeLoss.major*100,worstRelativeLoss.minor)
-                            print 'Test {} out of {}: {}, {}'.format(testNum,numOfTests,worstAbsoluteLossStr,worstRelativeLossStr)
     except KeyboardInterrupt:
         print 'Process aborted by user request'
     


### PR DESCRIPTION
1. Make it clear that we run each test-case of amount <= supply (instead of using the 'continue' statement on the opposite expression).
2. Print consecutively (makes it a little slower, but also makes the printouts coming at a constant rate).