### PR TITLE
Fix the Purchase coverage test

### DIFF
--- a/solidity/python/CoveragePurchase.py
+++ b/solidity/python/CoveragePurchase.py
@@ -43,7 +43,7 @@ def Main():
             for         reserve in range_reserve:
                 for     ratio   in range_ratio  :
                     for amount  in range_amount :
-                        if amount <= supply or amount <= reserve:
+                        if amount <= reserve:
                             fixed,real = Test(supply,reserve,ratio,amount)
                             if real < 0:
                                 pass # Transaction Invalid
@@ -57,9 +57,9 @@ def Main():
                                 relativeLoss = 1-fixed/real
                                 worstAbsoluteLoss.Update(supply,reserve,ratio,amount,fixed,real,absoluteLoss,relativeLoss)
                                 worstRelativeLoss.Update(supply,reserve,ratio,amount,fixed,real,relativeLoss,absoluteLoss)
-                        worstAbsoluteLossStr = 'worstAbsoluteLoss = {:.0f} (relativeLoss = {:.0f}%)'.format(worstAbsoluteLoss.major,worstAbsoluteLoss.minor*100)
-                        worstRelativeLossStr = 'worstRelativeLoss = {:.0f}% (absoluteLoss = {:.0f})'.format(worstRelativeLoss.major*100,worstRelativeLoss.minor)
-                        print 'Test {} out of {}: {}, {}'.format(testNum,numOfTests,worstAbsoluteLossStr,worstRelativeLossStr)
+                                worstAbsoluteLossStr = 'worstAbsoluteLoss = {:.0f} (relativeLoss = {:.0f}%)'.format(worstAbsoluteLoss.major,worstAbsoluteLoss.minor*100)
+                                worstRelativeLossStr = 'worstRelativeLoss = {:.0f}% (absoluteLoss = {:.0f})'.format(worstRelativeLoss.major*100,worstRelativeLoss.minor)
+                                print 'Test {} out of {}: {}, {}'.format(testNum,numOfTests,worstAbsoluteLossStr,worstRelativeLossStr)
                         testNum += 1
     except KeyboardInterrupt:
         print 'Process aborted by user request'


### PR DESCRIPTION
1. Print only when needed (otherwise the test is much slower)
2. Skip all cases of amount > reserve