### PR TITLE
Start the precision loop from 32 and not from 0

### DIFF
--- a/solidity/test/BancorFormula.js
+++ b/solidity/test/BancorFormula.js
@@ -29,7 +29,7 @@ function num(numericStr) {
 }
 
 contract('BancorFormula', () => {
-    for (var precision = 0; precision < 128; precision++) {
+    for (var precision = 32; precision < 128; precision++) {
         it('handles legal input ranges (fixedExp)', () => {
             return BancorFormula.deployed().then((instance) => {
                 let ok = testArrays.maxExpArray[precision];


### PR DESCRIPTION
he auto-generated arrays contain info for precision 0 - 127, but the contract can only handle precision 32 - 127.