### PR TITLE
validateGasPrice does not allow lower gas prices

### DIFF
--- a/solidity/contracts/BancorGasPriceLimit.sol
+++ b/solidity/contracts/BancorGasPriceLimit.sol
@@ -58,6 +58,6 @@ contract BancorGasPriceLimit is IBancorGasPriceLimit, Owned, Utils {
         view
         greaterThanZero(_gasPrice)
     {
-        require(_gasPrice == gasPrice);
+        require(_gasPrice <= gasPrice);
     }
 }


### PR DESCRIPTION
Hi all,

Not sure if it was intentional, but I've noticed that the new [BancorGasLimit contract](https://etherscan.io/address/0x7fd539ef2be3192b6d6bdf095968bac2d74daa6e) deployed yesterday somehow only validates gas prices exactly the set price and does not allow lower prices.

This has led to tx failures such as [this one](https://etherscan.io/tx/0x86c599aa7c811aa9c290020d12acd6b743db2de84cc3b2aebf251802fef5b434). On the contrary, the only [transactions](https://etherscan.io/tx/0xf9046e7615e02cd153703a1c721626dcbdc44fac615a48f00a24bd9fb9405012) that worked are those with gas price set exactly the limit price (5 Gwei).

In addition, Etherscan.io is no longer able to display the contract's gasPrice because validateGasPrice() would fail on contract read:
<img width="621" alt="screen shot 2018-04-05 at 12 56 47 am" src="https://user-images.githubusercontent.com/1946265/38353870-acdfd712-386c-11e8-8000-c45a92f6351e.png">
