### PR TITLE
Test mnemonic fix

### DIFF
--- a/solidity/test/BancorNetwork.js
+++ b/solidity/test/BancorNetwork.js
@@ -63,7 +63,7 @@ Token network structure:
 
 */
 
-contract.only('BancorNetwork', accounts => {
+contract('BancorNetwork', accounts => {
     const trustedAddress = accounts[3];
     const untrustedAddress = accounts[1];
 


### PR DESCRIPTION
trusted/untrusted private keys are no longer hardcoded into the tests (So ganache will work with any mnemonic), and have been replaces with accounts[3] and accounts[1] (addresses) respectively.