### PR TITLE
1. Change 2 occurrences of `assert` to `require`, because both cases …

### DIFF
--- a/solidity/contracts/converter/BancorFormula.sol
+++ b/solidity/contracts/converter/BancorFormula.sol
@@ -30,7 +30,7 @@ contract BancorFormula is IBancorFormula, Utils {
     uint256 private constant OPT_EXP_MAX_VAL = 0x800000000000000000000000000000000;
 
     /**
-        Auto-generated via 'PrintFunctionBancorFormula.py'
+        Auto-generated via 'PrintFunctionConstructor.py'
     */
     uint256[128] private maxExpArray;
     constructor() public {
@@ -287,7 +287,7 @@ contract BancorFormula is IBancorFormula, Utils {
             This functions assumes that "_expN < 2 ^ 256 / log(MAX_NUM - 1)", otherwise the multiplication should be replaced with a "safeMul".
     */
     function power(uint256 _baseN, uint256 _baseD, uint32 _expN, uint32 _expD) internal view returns (uint256, uint8) {
-        assert(_baseN < MAX_NUM);
+        require(_baseN < MAX_NUM);
 
         uint256 baseLog;
         uint256 base = _baseN * FIXED_1 / _baseD;
@@ -384,7 +384,7 @@ contract BancorFormula is IBancorFormula, Utils {
         if (maxExpArray[lo] >= _x)
             return lo;
 
-        assert(false);
+        require(false);
         return 0;
     }
 

--- a/solidity/python/AutoGenerate/PrintFunctionConstructor.py
+++ b/solidity/python/AutoGenerate/PrintFunctionConstructor.py
@@ -15,7 +15,7 @@ len2 = len(hex(maxExpArrayShl[0]))
 
 
 print('    uint256[{}] private maxExpArray;'.format(len(maxExpArray)))
-print('    function BancorFormula() public {')
+print('    constructor() public {')
 for precision in range(len(maxExpArray)):
     prefix = '  ' if MIN_PRECISION <= precision <= MAX_PRECISION else '//'
     print('    {0:s}  maxExpArray[{1:{2}d}] = {3:#0{4}x};'.format(prefix,precision,len1,maxExpArrayShl[precision],len2))

--- a/solidity/test/BancorFormula.js
+++ b/solidity/test/BancorFormula.js
@@ -2,8 +2,8 @@
 /* eslint-disable prefer-reflect, no-loop-func */
 
 let constants = require('./helpers/FormulaConstants.js');
+let catchRevert = require('./helpers/Utils.js').catchRevert;
 let TestBancorFormula = artifacts.require('./helpers/TestBancorFormula.sol');
-let ERROR_MESSAGE = 'invalid opcode';
 
 contract('BancorFormula', () => {
     let formula;
@@ -24,13 +24,7 @@ contract('BancorFormula', () => {
         let test  = `Function power(0x${baseN.toString(16)}, 0x${baseD.toString(16)}, ${expN}, ${expD})`;
 
         it(`${test}:`, async () => {
-            try {
-                let retVal = await formula.powerTest(baseN, baseD, expN, expD);
-                assert(percent <= 100, `${test} passed when it should have failed`);
-            }
-            catch (error) {
-                assert(percent >= 101 && error.toString().includes(ERROR_MESSAGE), error.message);
-            }
+            await formula.powerTest(baseN, baseD, expN, expD);
         });
     }
 
@@ -42,13 +36,7 @@ contract('BancorFormula', () => {
         let test  = `Function power(0x${baseN.toString(16)}, 0x${baseD.toString(16)}, ${expN}, ${expD})`;
 
         it(`${test}:`, async () => {
-            try {
-                let retVal = await formula.powerTest(baseN, baseD, expN, expD);
-                assert(percent <= 100, `${test} passed when it should have failed`);
-            }
-            catch (error) {
-                assert(percent >= 101 && error.toString().includes(ERROR_MESSAGE), error.message);
-            }
+            await formula.powerTest(baseN, baseD, expN, expD);
         });
     }
 
@@ -60,13 +48,10 @@ contract('BancorFormula', () => {
         let test  = `Function power(0x${baseN.toString(16)}, 0x${baseD.toString(16)}, ${expN}, ${expD})`;
 
         it(`${test}:`, async () => {
-            try {
-                let retVal = await formula.powerTest(baseN, baseD, expN, expD);
-                assert(percent <= 63, `${test} passed when it should have failed`);
-            }
-            catch (error) {
-                assert(percent >= 64 && error.toString().includes(ERROR_MESSAGE), error.message);
-            }
+            if (percent < 64)
+                await formula.powerTest(baseN, baseD, expN, expD);
+            else
+                await catchRevert(formula.powerTest(baseN, baseD, expN, expD));
         });
     }
 
@@ -78,13 +63,7 @@ contract('BancorFormula', () => {
         let test  = `Function power(0x${baseN.toString(16)}, 0x${baseD.toString(16)}, ${expN}, ${expD})`;
 
         it(`${test}:`, async () => {
-            try {
-                let retVal = await formula.powerTest(baseN, baseD, expN, expD);
-                assert(percent <= 0, `${test} passed when it should have failed`);
-            }
-            catch (error) {
-                assert(percent >= 1 && error.toString().includes(ERROR_MESSAGE), error.message);
-            }
+            await catchRevert(formula.powerTest(baseN, baseD, expN, expD));
         });
     }
 
@@ -124,13 +103,12 @@ contract('BancorFormula', () => {
             let test   = `Function findPositionInMaxExpArray(0x${input.toString(16)})`;
 
             it(`${test}:`, async () => {
-                try {
+                if (precision == constants.MIN_PRECISION && output.lessThan(web3.toBigNumber(precision))) {
+                    await catchRevert(formula.findPositionInMaxExpArrayTest(input));
+                }
+                else {
                     let retVal = await formula.findPositionInMaxExpArrayTest(input);
                     assert(retVal.equals(output), `${test}: output should be ${output.toString(10)} but it is ${retVal.toString(10)}`);
-                    assert(precision > constants.MIN_PRECISION || !output.lessThan(web3.toBigNumber(precision)), `${test} passed when it should have failed`);
-                }
-                catch (error) {
-                    assert(precision == constants.MIN_PRECISION && output.lessThan(web3.toBigNumber(precision)) && error.toString().includes(ERROR_MESSAGE), error.message);
                 }
             });
         }

--- a/solidity/test/helpers/Utils.js
+++ b/solidity/test/helpers/Utils.js
@@ -9,8 +9,28 @@ function ensureException(error) {
     assert(isException(error), error.toString());
 }
 
+const PREFIX = "VM Exception while processing transaction: ";
+
+async function tryCatch(promise, message) {
+    try {
+        await promise;
+        throw null;
+    }
+    catch (error) {
+        assert(error, "Expected an error but did not get one");
+        assert(error.message.startsWith(PREFIX + message), "Expected an error starting with '" + PREFIX + message + "' but got '" + error.message + "' instead");
+    }
+};
+
 module.exports = {
-    zeroAddress: '0x0000000000000000000000000000000000000000',
-    isException: isException,
-    ensureException: ensureException
+    zeroAddress            : '0x0000000000000000000000000000000000000000',
+    isException            : isException,
+    ensureException        : ensureException,
+    catchRevert            : async function(promise) {await tryCatch(promise, "revert"             );},
+    catchOutOfGas          : async function(promise) {await tryCatch(promise, "out of gas"         );},
+    catchInvalidJump       : async function(promise) {await tryCatch(promise, "invalid JUMP"       );},
+    catchInvalidOpcode     : async function(promise) {await tryCatch(promise, "invalid opcode"     );},
+    catchStackOverflow     : async function(promise) {await tryCatch(promise, "stack overflow"     );},
+    catchStackUnderflow    : async function(promise) {await tryCatch(promise, "stack underflow"    );},
+    catchStaticStateChange : async function(promise) {await tryCatch(promise, "static state change");},
 };


### PR DESCRIPTION
…apply to user-input.

2. Fix contract's test to catch `revert` messages instead of `invalid opcode` messages.
3. Add infrastructure for catching all types of exceptions easily (in file ./helpers/Utils.js).
4. Fix the Python script for auto-generating BancorFormula constructor to print `constructor` keyword.