### PR TITLE
Updating to explain explicitly declare caller

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ As such, it implements both the standard token methods and the standard token ev
 
 ### Methods
 
-Note that these methods can only be executed by the token owner.
-
 **issue**
 ```cs
 function issue(address _to, uint256 _amount)
@@ -56,6 +54,26 @@ Removes tokens from an account and decreases the token supply.
 function disableTransfers(bool _disable)
 ```
 Disables transfer/transferFrom functionality.
+
+#### Please note:
+These methods can only be executed by the token owner. If you are calling these methods in a console (command line) the token owner is not implied. If you want to execute the method and explicitly provide the token owner, please use the following syntax.
+
+```
+deployedContract.issue(address _to, uint256 _amount, {from:address _owner});
+```
+
+```
+deployedContract.issue("0xf7fca0066bde97e5509591afc9f669991e03c25c",10000000000, {from:"0xcbd78e5779fee36b87c58276ff86fb444a574092"});
+```
+This syntax can also be used on methods which require no arguments, as shown below.
+
+```
+deployedContract.acceptOwnership({from:address _owner});
+```
+
+```
+deployedContract.acceptOwnership({from:"0xcbd78e5779fee36b87c58276ff86fb444a574092"});
+```
 <br>
 <br>
 <br>


### PR DESCRIPTION
There are modifiers which check the message sender. If calling the functions via a command line the contract owner/message sender is not implied. Obviously using MetaMask etc. does this behind the scenes. Below are a couple of examples of how an error will occur in the event that a message sender is not explicitly added to the method call in the command line.
```
deployedContract.acceptOwnership();
Error: invalid address
    at web3-cmt.js:12250:13
    at web3-cmt.js:12080:18
    at web3-cmt.js:13332:28
    at map (<native code>)
    at web3-cmt.js:13331:12
    at web3-cmt.js:13357:18
    at web3-cmt.js:13382:23
    at web3-cmt.js:12448:16
    at apply (<native code>)
    at web3-cmt.js:12534:16
```

```
deployedContract.issue({from:"0xf7fca0066bde97e5509591afc9f669991e03c25c"},10000000000);
Error: Invalid number of arguments to Solidity function
    at web3-cmt.js:11459:20
    at web3-cmt.js:12352:15
    at web3-cmt.js:12368:5
    at web3-cmt.js:12441:19
    at apply (<native code>)
    at web3-cmt.js:12534:16
    at <anonymous>:1:1
```