### PR TITLE
A platform-independent (OS agnostic) infrastructure for executing `tr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,10 @@ Tests are included and can be run using truffle & ganache
 
 ### Prerequisites
 * Node.js v7.6.0+
-* truffle v4.1.5+
-* ganache v1.1.0+
 
-To run the test, first start ganache and then execute the following command from the project's root folder -
-* npm test
+To run the test:
+- Use `npm install` in order to install all required packages.
+- Use `npm test` in order to run truffle-test or solidity-coverage.
 
 ## Collaborators
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "npm": "^3.0.0"
   },
   "scripts": {
-    "test": "cd solidity && truffle test"
+    "install": "node scripts/fix-modules.js",
+    "test": "node scripts/run-tests.js"
   },
   "dependencies": {
     "decimal.js": "^10.0.1",
@@ -18,6 +19,10 @@
     "js-sha256": "^0.9.0",
     "left-pad": "^1.3.0",
     "npm": "^6.1.0",
+    "truffle": "4.1.14",
+    "ganache-cli": "6.1.8",
+    "solidity-coverage": "0.5.8",
+    "ethereumjs-testrpc-sc": "6.1.6",
     "web3-utils": "^1.0.0-beta.34"
   }
 }

--- a/scripts/fix-modules.js
+++ b/scripts/fix-modules.js
@@ -1,0 +1,25 @@
+let fs = require("fs");
+
+function fix(fileName, tokens) {
+    console.log("Fixing " + fileName);
+    let data = fs.readFileSync(fileName, {encoding: "utf8"});
+    for (let token of tokens)
+        data = data.split(token.prev).join(token.next);
+    fs.writeFileSync(fileName, data, {encoding: "utf8"});
+}
+
+fix("./node_modules/truffle/build/cli.bundled.js", [
+    {prev: "request = new XHR2", next: "request = new XMLHttpRequest"},
+    {prev: "error = errors.InvalidResponse", next: "error = payload.method === 'evm_revert' || payload.method === 'evm_snapshot' ? null : errors.InvalidResponse"}]
+);
+
+fix("./node_modules/solidity-coverage/lib/app.js", [
+    {prev: "events.push", next: "coverage.processEvent"}]
+);
+
+fix("./node_modules/solidity-coverage/lib/coverageMap.js", [
+    {prev: "  generate(events, pathPrefix) {", next: "  processEvent(line) {"},
+    {prev: "    for (let idx = 0; idx < events.length; idx++) {", next: ""},
+    {prev: "      const event = JSON.parse(events[idx]);", next: "      const event = JSON.parse(line);"},
+    {prev: "    // Finally, interpret the assert pre/post events", next: "  generate(events, pathPrefix) {"}]
+);

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,0 +1,67 @@
+let TRUFFLE_TEST = "1";
+let SOL_COVERAGE = "2";
+
+let WORK_DIR = "./solidity";
+let NODE_DIR = "../node_modules";
+
+let spawn = require("child_process").spawn;
+
+function getArgs(id, args) {
+    switch (id) {
+        case TRUFFLE_TEST: return args.TRUFFLE_TEST;
+        case SOL_COVERAGE: return args.SOL_COVERAGE;
+    }
+    throw `invalid input = '${id}'`;
+}
+
+function server(id) {
+    let args = getArgs(id, {
+        TRUFFLE_TEST: [NODE_DIR + "/ganache-cli/build/cli.node.js"          , "--port=7545"],
+        SOL_COVERAGE: [NODE_DIR + "/ethereumjs-testrpc-sc/build/cli.node.js", "--port=7555"],
+    });
+    let cp = spawn("node", [...args,
+        "--gasLimit=0xfffffffffff",
+        "--account=0x0000000000000000000000000000000000000000000000000000000000000001,1000000000000000000000000000000000000000",
+        "--account=0x0000000000000000000000000000000000000000000000000000000000000002,1000000000000000000000000000000000000000",
+        "--account=0x0000000000000000000000000000000000000000000000000000000000000003,1000000000000000000000000000000000000000",
+        "--account=0x0000000000000000000000000000000000000000000000000000000000000004,1000000000000000000000000000000000000000",
+        "--account=0x0000000000000000000000000000000000000000000000000000000000000005,1000000000000000000000000000000000000000",
+        "--account=0x0000000000000000000000000000000000000000000000000000000000000006,1000000000000000000000000000000000000000",
+        "--account=0x0000000000000000000000000000000000000000000000000000000000000007,1000000000000000000000000000000000000000",
+        "--account=0x0000000000000000000000000000000000000000000000000000000000000008,1000000000000000000000000000000000000000",
+        "--account=0x0000000000000000000000000000000000000000000000000000000000000009,1000000000000000000000000000000000000000",
+        "--account=0x000000000000000000000000000000000000000000000000000000000000000a,1000000000000000000000000000000000000000"], {cwd: WORK_DIR});
+    cp.stdout.on("data", function(data) {/*process.stdout.write(data.toString());*/});
+    cp.stderr.on("data", function(data) {process.stderr.write(data.toString());});
+    cp.on("error", function(error) {process.stderr.write(error.toString());});
+    return cp;
+}
+
+function client(id) {
+    let args = getArgs(id, {
+        TRUFFLE_TEST: [NODE_DIR + "/truffle/build/cli.bundled.js", "test"],
+        SOL_COVERAGE: [NODE_DIR + "/solidity-coverage/bin/exec.js"       ],
+    });
+    let cp = spawn("node", args, {cwd: WORK_DIR});
+    cp.stdout.on("data", function(data) {process.stdout.write(data.toString());});
+    cp.stderr.on("data", function(data) {process.stderr.write(data.toString());});
+    cp.on("error", function(error) {process.stderr.write(error.toString());});
+    return cp;
+}
+
+function execute(id) {
+    let server_cp = server(id);
+    let client_cp = client(id);
+    client_cp.on("exit", function(code, signal) {server_cp.kill();});
+}
+
+if (process.argv.length > 2) {
+    execute(process.argv[2]);
+}
+else {
+    process.stdout.write(`Enter '${TRUFFLE_TEST}' for truffle-test or '${SOL_COVERAGE}' for solidity-coverage: `);
+    process.stdin.on("data", function(data) {
+        process.stdin.end();
+        execute(data.toString().trim());
+    });
+}

--- a/solidity/.solcover.js
+++ b/solidity/.solcover.js
@@ -1,0 +1,7 @@
+// See <https://www.npmjs.com/package/solidity-coverage#options>
+module.exports = {
+    port:           7555,
+    norpc:          true,
+    testCommand:    "node ../../node_modules/truffle/build/cli.bundled.js test --network=coverage",
+    compileCommand: "node ../../node_modules/truffle/build/cli.bundled.js compile --network=coverage",
+};

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -20,25 +20,27 @@ const BancorConverterFactory = artifacts.require('BancorConverterFactory.sol');
 const BancorConverterUpgrader = artifacts.require('BancorConverterUpgrader.sol');
 const CrowdsaleController = artifacts.require('CrowdsaleController.sol');
 
-module.exports = async deployer => {
-    deployer.deploy(Utils);
-    deployer.deploy(Owned);
-    deployer.deploy(Managed);
-    deployer.deploy(TokenHolder);
-    deployer.deploy(ERC20Token, 'DummyToken', 'DUM', 0);
-    deployer.deploy(EtherToken);
-    await deployer.deploy(ContractRegistry);
-    deployer.deploy(ContractFeatures);
-    deployer.deploy(Whitelist);
-    await deployer.deploy(SmartToken, 'Token1', 'TKN1', 2);
-    deployer.deploy(SmartTokenController, SmartToken.address);
-    deployer.deploy(BancorFormula);
-    deployer.deploy(BancorGasPriceLimit, '22000000000');
-    deployer.deploy(BancorNetwork, ContractRegistry.address);
-    deployer.deploy(BancorConverter, SmartToken.address, ContractRegistry.address, 0, '0x0', 0);
+module.exports = async function(deployer, network, accounts) {
+    if (network == "production") {
+        deployer.deploy(Utils);
+        deployer.deploy(Owned);
+        deployer.deploy(Managed);
+        deployer.deploy(TokenHolder);
+        deployer.deploy(ERC20Token, 'DummyToken', 'DUM', 0);
+        deployer.deploy(EtherToken);
+        await deployer.deploy(ContractRegistry);
+        deployer.deploy(ContractFeatures);
+        deployer.deploy(Whitelist);
+        await deployer.deploy(SmartToken, 'Token1', 'TKN1', 2);
+        deployer.deploy(SmartTokenController, SmartToken.address);
+        deployer.deploy(BancorFormula);
+        deployer.deploy(BancorGasPriceLimit, '22000000000');
+        deployer.deploy(BancorNetwork, ContractRegistry.address);
+        deployer.deploy(BancorConverter, SmartToken.address, ContractRegistry.address, 0, '0x0', 0);
 
-    await deployer.deploy(BancorConverterFactory);
-    await deployer.deploy(BancorConverterUpgrader, ContractRegistry.address);
+        await deployer.deploy(BancorConverterFactory);
+        await deployer.deploy(BancorConverterUpgrader, ContractRegistry.address);
 
-    deployer.deploy(CrowdsaleController, SmartToken.address, 4102444800, '0x125', '0x126', 1);
+        deployer.deploy(CrowdsaleController, SmartToken.address, 4102444800, '0x125', '0x126', 1);
+    }
 };

--- a/solidity/truffle-config.js
+++ b/solidity/truffle-config.js
@@ -1,17 +1,37 @@
+// See <http://truffleframework.com/docs/advanced/configuration>
 module.exports = {
     networks: {
         development: {
-            host: "localhost",
-            port: 7545,
-            network_id: "*", // Match any network id
-            gasPrice: 20000000000,
-            gas: 5712388
+            host:       "localhost",
+            port:       7545,
+            network_id: "*",          // Match any network id
+            gasPrice:   20000000000,  // Gas price used for deploys
+            gas:        5712388       // Gas limit used for deploys
+        },
+        production: {
+            host:       "localhost",
+            port:       7545,
+            network_id: "*",          // Match any network id
+            gasPrice:   20000000000,  // Gas price used for deploys
+            gas:        5712388       // Gas limit used for deploys
+        },
+        coverage: {     // See <https://www.npmjs.com/package/solidity-coverage#network-configuration>
+            host:       "localhost",
+            port:       7555,         // Also in .solcover.js
+            network_id: "*",          // Match any network id
+            gasPrice:   0x01,         // Gas price used for deploys
+            gas:        0xfffffffffff // Gas limit used for deploys
         }
+    },
+    mocha: {
+        enableTimeouts: false,
+        useColors:      true,
+        bail:           true
     },
     solc: {
         optimizer: {
             enabled: true,
-            runs: 5000000
+            runs:    5000000
         }
     }
 };


### PR DESCRIPTION
…uffle test` and `solidity coverage` via `npm test`.

Advantages:
- It is completely platform-independent, since it runs on NodeJS.
- It relieves the user from running `ganache-cli` before running `truffle test` (in two separate processes).
- It relieves the user from running `testrpc-sc` before running `solidity-coverage` (in two separate processes).

Usage:
- First, run `npm install` in order to install all required packages.
- Then, run `npm test` in order to run truffle-test or solidity-coverage.
- You can also run `npm test 1` or `npm test 2` in order to execute them directly.

Note:
All related testing tools (Truffle, Ganache, TestRpc and SolidityCoverage) are now added to the `package.json` file.
This means that they are installed locally, which may possibly collide with any previous global installation of these tools.
If you choose to remove all related global installations, then:
Please note that commands like `truffle test`, `ganache-cli` and `solidity-coverage` might not work from every path.
Moreover, they might not work even from the project's pass, because they are not added to the operating system search path when installed locally.
Therefore, you can either add their paths to the operating system search path manually, or call each one of them from its specific path, for example:
- Instead of `ganache-cli --port=7545`, run from the `solidity` folder: `node ../node_modules/ganache-cli/build/cli.node.js --port=7545`
- Instead of `testrpc-sc --port=7555`,  run from the `solidity` folder: `node ../node_modules/ethereumjs-testrpc-sc/build/cli.node.js --port=7555`
- Instead of `truffle test`,            run from the `solidity` folder: `node ../node_modules/truffle/build/cli.bundled.js test`
- Instead of `solidity-coverage`,       run from the `solidity` folder: `node ../node_modules/solidity-coverage/bin/exec.js`