### PR TITLE
quickBuyPath removed from contracts and tests

### DIFF
--- a/solidity/contracts/converter/BancorConverter.sol
+++ b/solidity/contracts/converter/BancorConverter.sol
@@ -52,7 +52,6 @@ contract BancorConverter is IBancorConverter, SmartTokenController, Managed, Con
     IContractRegistry public registry;                  // contract registry contract
     IWhitelist public conversionWhitelist;              // whitelist contract with list of addresses that are allowed to use the converter
     IERC20Token[] public connectorTokens;               // ERC20 standard token addresses
-    IERC20Token[] public quickBuyPath;                  // conversion path that's used in order to buy the token with ETH
     mapping (address => Connector) public connectors;   // connector token addresses -> connector data
     uint32 private totalConnectorWeight = 0;            // used to efficiently prevent increasing the total connector weight above 100%
     uint32 public maxConversionFee = 0;                 // maximum conversion fee for the lifetime of the contract,
@@ -198,35 +197,6 @@ contract BancorConverter is IBancorConverter, SmartTokenController, Managed, Con
         notThis(_whitelist)
     {
         conversionWhitelist = _whitelist;
-    }
-
-    /*
-        @dev allows the manager to update the quick buy path
-
-        @param _path    new quick buy path, see conversion path format in the bancorNetwork contract
-    */
-    function setQuickBuyPath(IERC20Token[] _path)
-        public
-        ownerOnly
-        validConversionPath(_path)
-    {
-        quickBuyPath = _path;
-    }
-
-    /*
-        @dev allows the manager to clear the quick buy path
-    */
-    function clearQuickBuyPath() public ownerOnly {
-        quickBuyPath.length = 0;
-    }
-
-    /**
-        @dev returns the length of the quick buy path array
-
-        @return quick buy path length
-    */
-    function getQuickBuyPathLength() public view returns (uint256) {
-        return quickBuyPath.length;
     }
 
     /**
@@ -824,13 +794,5 @@ contract BancorConverter is IBancorConverter, SmartTokenController, Managed, Con
         // since we convert it to a signed number, we first ensure that it's capped at 255 bits to prevent overflow
         assert(_feeAmount <= 2 ** 255);
         emit Conversion(_fromToken, _toToken, msg.sender, _amount, _returnAmount, int256(_feeAmount));
-    }
-
-    /**
-        @dev fallback, buys the smart token with ETH
-        note that the purchase will use the price at the time of the purchase
-    */
-    function() payable public {
-        quickConvert(quickBuyPath, msg.value, 1);
     }
 }

--- a/solidity/contracts/converter/BancorConverterUpgrader.sol
+++ b/solidity/contracts/converter/BancorConverterUpgrader.sol
@@ -14,7 +14,6 @@ import '../FeatureIds.sol';
 */
 contract IBancorConverterExtended is IBancorConverter, IOwned {
     function token() public view returns (ISmartToken) {}
-    function quickBuyPath(uint256 _index) public view returns (IERC20Token) { _index; }
     function maxConversionFee() public view returns (uint32) {}
     function conversionFee() public view returns (uint32) {}
     function connectorTokenCount() public view returns (uint16);
@@ -22,14 +21,12 @@ contract IBancorConverterExtended is IBancorConverter, IOwned {
     function connectorTokens(uint256 _index) public view returns (IERC20Token) { _index; }
     function reserveTokens(uint256 _index) public view returns (IERC20Token) { _index; }
     function setConversionWhitelist(IWhitelist _whitelist) public;
-    function getQuickBuyPathLength() public view returns (uint256);
     function transferTokenOwnership(address _newOwner) public;
     function withdrawTokens(IERC20Token _token, address _to, uint256 _amount) public;
     function acceptTokenOwnership() public;
     function transferManagement(address _newManager) public;
     function acceptManagement() public;
     function setConversionFee(uint32 _conversionFee) public;
-    function setQuickBuyPath(IERC20Token[] _path) public;
     function addConnector(IERC20Token _token, uint32 _weight, bool _enableVirtualBalance) public;
     function updateConnector(IERC20Token _connectorToken, uint32 _weight, bool _enableVirtualBalance, uint256 _virtualBalance) public;
     function getConnectorBalance(IERC20Token _connectorToken) public view returns (uint256);
@@ -112,7 +109,6 @@ contract BancorConverterUpgrader is IBancorConverterUpgrader, Owned, ContractIds
         IBancorConverterExtended newConverter = createConverter(converter);
         copyConnectors(converter, newConverter, formerVersions);
         copyConversionFee(converter, newConverter);
-        copyQuickBuyPath(converter, newConverter);
         transferConnectorsBalances(converter, newConverter, formerVersions);                
         ISmartToken token = converter.token();
 
@@ -222,25 +218,6 @@ contract BancorConverterUpgrader is IBancorConverterUpgrader, Owned, ContractIds
     function copyConversionFee(IBancorConverterExtended _oldConverter, IBancorConverterExtended _newConverter) private {
         uint32 conversionFee = _oldConverter.conversionFee();
         _newConverter.setConversionFee(conversionFee);
-    }
-
-    /**
-        @dev copies the quick buy path from the old converter to the new one
-
-        @param _oldConverter    old converter contract address
-        @param _newConverter    new converter contract address
-    */
-    function copyQuickBuyPath(IBancorConverterExtended _oldConverter, IBancorConverterExtended _newConverter) private {
-        uint256 quickBuyPathLength = _oldConverter.getQuickBuyPathLength();
-        if (quickBuyPathLength <= 0)
-            return;
-
-        IERC20Token[] memory path = new IERC20Token[](quickBuyPathLength);
-        for (uint256 i = 0; i < quickBuyPathLength; i++) {
-            path[i] = _oldConverter.quickBuyPath(i);
-        }
-
-        _newConverter.setQuickBuyPath(path);
     }
 
     /**

--- a/solidity/test/BancorConverterUpgrader.js
+++ b/solidity/test/BancorConverterUpgrader.js
@@ -54,9 +54,6 @@ async function initConverter(accounts, activate, version = null, maxConversionFe
     await connectorToken2.transfer(converterAddress, 8000);
     await converter.setConversionFee(1000);
 
-    let smartToken1QuickBuyPath = [connectorTokenAddress, tokenAddress, tokenAddress];
-    await converter.setQuickBuyPath(smartToken1QuickBuyPath);
-
     if (activate) {
         await token.transferOwnership(converterAddress);
         await converter.acceptTokenOwnership();
@@ -185,29 +182,6 @@ contract('BancorConverterUpgrader', accounts => {
             let newManager = await newConverter.newManager.call();
             assert.equal(initialManager, newManager);    
         }
-    });
-
-    it('verifies that the quick buy path length of the converter is equal to the path length in the new converter', async () => {
-        for (let i = 0; i < versions.length; i++) {
-            let converter = await initConverter(accounts, true, versions[i]);
-            let initialLength = await converter.getQuickBuyPathLength.call();
-            let newConverter = await upgradeConverter(converter, versions[i]);
-            let newLength = await newConverter.getQuickBuyPathLength.call();
-            assert.equal(initialLength.toFixed(), newLength.toFixed());    
-        }                
-    });
-
-    it('verifies that the quick buy path of the new converter is equal to the path in the old converter', async () => {
-        for (let i = 0; i < versions.length; i++) {
-            let converter = await initConverter(accounts, true, versions[i]);
-            let initialPathLength = await converter.getQuickBuyPathLength.call();
-            let newConverter = await upgradeConverter(converter, versions[i]);
-            for (let i = 0; i < initialPathLength; i++) {
-                let initialToken = await converter.quickBuyPath.call(i);
-                let currentToken = await newConverter.quickBuyPath.call(i);
-                assert.equal(initialToken, currentToken);
-            }    
-        }                
     });
 
     it('verifies that the whitelist feature is enabled in the new converter', async () => {

--- a/solidity/test/BancorNetwork.js
+++ b/solidity/test/BancorNetwork.js
@@ -30,13 +30,10 @@ let converter2;
 let converter3;
 let converter4;
 let bancorNetwork;
-let smartToken1QuickBuyPath;
-let smartToken2QuickBuyPath;
-let smartToken3QuickBuyPath;
-let smartToken4QuickBuyPath;
-let erc20QuickBuyPath;
-let smartToken1QuickSellPath;
-let smartToken2QuickSellPath;
+let smartToken1BuyPath;
+let smartToken2BuyPath;
+let smartToken1SellPath;
+let smartToken2SellPath;
 let defaultGasPriceLimit = BancorGasPriceLimit.class_defaults.gasPrice;
 
 function sign(msgToSign, signerAddress) {
@@ -136,20 +133,17 @@ contract('BancorNetwork', accounts => {
         await smartToken4.transferOwnership(converter4.address);
         await converter4.acceptTokenOwnership();
 
-        smartToken1QuickBuyPath = [etherToken.address, smartToken1.address, smartToken1.address];
-        smartToken2QuickBuyPath = [etherToken.address, smartToken1.address, smartToken1.address, smartToken2.address, smartToken2.address];
-        smartToken3QuickBuyPath = [etherToken.address, smartToken4.address, smartToken4.address, smartToken3.address, smartToken4.address];
-        smartToken4QuickBuyPath = [etherToken.address, smartToken4.address, smartToken4.address];
-        erc20QuickBuyPath = [etherToken.address, smartToken4.address, erc20Token.address];
+        smartToken1BuyPath = [etherToken.address, smartToken1.address, smartToken1.address];
+        smartToken2BuyPath = [etherToken.address, smartToken1.address, smartToken1.address, smartToken2.address, smartToken2.address];
 
-        smartToken1QuickSellPath = [smartToken1.address, smartToken1.address, etherToken.address];
-        smartToken2QuickSellPath = [smartToken2.address, smartToken2.address, smartToken1.address, smartToken1.address, etherToken.address];
+        smartToken1SellPath = [smartToken1.address, smartToken1.address, etherToken.address];
+        smartToken2SellPath = [smartToken2.address, smartToken2.address, smartToken1.address, smartToken1.address, etherToken.address];
     });
 
     it('verifies that quick buy with a single converter results in increased balance for the buyer', async () => {
         let prevBalance = await smartToken1.balanceOf.call(accounts[1]);
 
-        await converter1.quickConvert(smartToken1QuickBuyPath, 100, 1, { from: accounts[1], value: 100 });
+        await converter1.quickConvert(smartToken1BuyPath, 100, 1, { from: accounts[1], value: 100 });
         let newBalance = await smartToken1.balanceOf.call(accounts[1]);
 
         assert.isAbove(newBalance.toNumber(), prevBalance.toNumber(), "new balance isn't higher than previous balance");
@@ -158,7 +152,7 @@ contract('BancorNetwork', accounts => {
     it('verifies that quick buy with multiple converters results in increased balance for the buyer', async () => {
         let prevBalance = await smartToken2.balanceOf.call(accounts[1]);
 
-        await converter2.quickConvert(smartToken2QuickBuyPath, 100, 1, { from: accounts[1], value: 100 });
+        await converter2.quickConvert(smartToken2BuyPath, 100, 1, { from: accounts[1], value: 100 });
         let newBalance = await smartToken2.balanceOf.call(accounts[1]);
 
         assert.isAbove(newBalance.toNumber(), prevBalance.toNumber(), "new balance isn't higher than previous balance");
@@ -180,7 +174,7 @@ contract('BancorNetwork', accounts => {
         let token1Return = (await converter1.getPurchaseReturn(etherToken.address, 100000))[0];
         let token2Return = (await converter2.getPurchaseReturn(smartToken1.address, token1Return))[0];
 
-        await converter2.quickConvert(smartToken2QuickBuyPath, 100000, token2Return, { value: 100000 });
+        await converter2.quickConvert(smartToken2BuyPath, 100000, token2Return, { value: 100000 });
         let newBalance = await smartToken2.balanceOf.call(accounts[0]);
 
         assert.equal(token2Return.toNumber(), newBalance.toNumber() - prevBalance.toNumber(), "new balance isn't equal to the expected purchase return");
@@ -188,7 +182,7 @@ contract('BancorNetwork', accounts => {
 
     it('should throw when attempting to quick buy and the return amount is lower than the given minimum', async () => {
         try {
-            await converter2.quickConvert(smartToken2QuickBuyPath, 100, 1000000, { from: accounts[1], value: 100 });
+            await converter2.quickConvert(smartToken2BuyPath, 100, 1000000, { from: accounts[1], value: 100 });
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -198,7 +192,7 @@ contract('BancorNetwork', accounts => {
 
     it('should throw when attempting to quick buy and passing an amount higher than the ETH amount sent with the request', async () => {
         try {
-            await converter2.quickConvert(smartToken2QuickBuyPath, 100001, 1, { from: accounts[1], value: 100000 });
+            await converter2.quickConvert(smartToken2BuyPath, 100001, 1, { from: accounts[1], value: 100000 });
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -210,7 +204,7 @@ contract('BancorNetwork', accounts => {
         let prevETHBalance = web3.eth.getBalance(accounts[0]);
         let prevTokenBalance = await smartToken1.balanceOf.call(accounts[0]);
 
-        let res = await converter1.quickConvert(smartToken1QuickSellPath, 10000, 1);
+        let res = await converter1.quickConvert(smartToken1SellPath, 10000, 1);
         let newETHBalance = web3.eth.getBalance(accounts[0]);
         let newTokenBalance = await smartToken1.balanceOf.call(accounts[0]);
 
@@ -224,7 +218,7 @@ contract('BancorNetwork', accounts => {
         let prevETHBalance = web3.eth.getBalance(accounts[0]);
         let prevTokenBalance = await smartToken2.balanceOf.call(accounts[0]);
 
-        let res = await converter2.quickConvert(smartToken2QuickSellPath, 10000, 1);
+        let res = await converter2.quickConvert(smartToken2SellPath, 10000, 1);
         let newETHBalance = web3.eth.getBalance(accounts[0]);
         let newTokenBalance = await smartToken2.balanceOf.call(accounts[0]);
 
@@ -236,7 +230,7 @@ contract('BancorNetwork', accounts => {
 
     it('should throw when attempting to sell directly for ether and the return amount is lower than the given minimum', async () => {
         try {
-            await converter2.quickConvert(smartToken2QuickSellPath, 10000, 20000);
+            await converter2.quickConvert(smartToken2SellPath, 10000, 20000);
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -325,7 +319,7 @@ contract('BancorNetwork', accounts => {
 
     it('verifies that convertFor transfers the converted amount correctly', async () => {
         let balanceBeforeTransfer = await smartToken1.balanceOf.call(accounts[1]);
-        await bancorNetwork.convertFor(smartToken1QuickBuyPath, 10000, 1, accounts[1], { value: 10000 });
+        await bancorNetwork.convertFor(smartToken1BuyPath, 10000, 1, accounts[1], { value: 10000 });
         let balanceAfterTransfer = await smartToken1.balanceOf.call(accounts[1]);
         assert.isAbove(balanceAfterTransfer.toNumber(), balanceBeforeTransfer.toNumber(), 'amount transfered');
     });
@@ -340,18 +334,18 @@ contract('BancorNetwork', accounts => {
     });
 
     it('verifies that convertFor returns the valid converted amount', async () => {
-        let amount = await bancorNetwork.convertFor.call(smartToken1QuickBuyPath, 10000, 1, accounts[1], { value: 10000 });
+        let amount = await bancorNetwork.convertFor.call(smartToken1BuyPath, 10000, 1, accounts[1], { value: 10000 });
         assert.isAbove(amount.toNumber(), 1, 'amount converted');
     });
 
     it('verifies that convert returns the valid converted amount', async () => {
-        let amount = await bancorNetwork.convert.call(smartToken1QuickBuyPath, 10000, 1, { from: accounts[1], value: 10000 });
+        let amount = await bancorNetwork.convert.call(smartToken1BuyPath, 10000, 1, { from: accounts[1], value: 10000 });
         assert.isAbove(amount.toNumber(), 1, 'amount converted');
     });
 
     it('should throw when trying convert ether token without sending ether', async () => {
         try {
-            await bancorNetwork.convertFor(smartToken1QuickBuyPath, 10000, 1, accounts[1], { });
+            await bancorNetwork.convertFor(smartToken1BuyPath, 10000, 1, accounts[1], { });
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -361,7 +355,7 @@ contract('BancorNetwork', accounts => {
 
     it('should throw when ether is different than the amount sent ', async () => {
         try {
-            await bancorNetwork.convertFor.call(smartToken1QuickBuyPath, 20000, 1, accounts[1], { value: 10000 });
+            await bancorNetwork.convertFor.call(smartToken1BuyPath, 20000, 1, accounts[1], { value: 10000 });
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -381,12 +375,12 @@ contract('BancorNetwork', accounts => {
     });
 
     it('should throw when trying convert with invalid long path', async () => {
-        let longQuickBuyPath = [];
+        let longBuyPath = [];
         for (let i = 0; i < 100; ++i)
-            longQuickBuyPath.push(etherToken.address);
+            longBuyPath.push(etherToken.address);
 
         try {
-            await bancorNetwork.convertFor(longQuickBuyPath, 10000, 1, accounts[1], { value: 10000 });
+            await bancorNetwork.convertFor(longBuyPath, 10000, 1, accounts[1], { value: 10000 });
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -397,14 +391,14 @@ contract('BancorNetwork', accounts => {
     it('verifies that convertFor transfers the converted amount correctly', async () => {
         await etherToken.approve(bancorNetwork.address, 10000);
         let balanceBeforeTransfer = await smartToken1.balanceOf.call(accounts[1]);
-        await bancorNetwork.claimAndConvertFor(smartToken1QuickBuyPath, 10000, 1, accounts[1]);
+        await bancorNetwork.claimAndConvertFor(smartToken1BuyPath, 10000, 1, accounts[1]);
         let balanceAfterTransfer = await smartToken1.balanceOf.call(accounts[1]);
         assert.isAbove(balanceAfterTransfer.toNumber(), balanceBeforeTransfer.toNumber(), 'amount transfered');
     });
 
     it('should throw when trying claim and convert without approval', async () => {
         try {
-            await bancorNetwork.claimAndConvertFor(smartToken1QuickBuyPath, 10000, 1, accounts[1]);
+            await bancorNetwork.claimAndConvertFor(smartToken1BuyPath, 10000, 1, accounts[1]);
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -415,14 +409,14 @@ contract('BancorNetwork', accounts => {
     it('verifies that convertFor transfers the converted amount correctly with claimAndConvert', async () => {
         await etherToken.approve(bancorNetwork.address, 10000);
         let balanceBeforeTransfer = await smartToken1.balanceOf.call(accounts[0]);
-        await bancorNetwork.claimAndConvert(smartToken1QuickBuyPath, 10000, 1);
+        await bancorNetwork.claimAndConvert(smartToken1BuyPath, 10000, 1);
         let balanceAfterTransfer = await smartToken1.balanceOf.call(accounts[0]);
         assert.isAbove(balanceAfterTransfer.toNumber(), balanceBeforeTransfer.toNumber(), 'amount transfered');
     });
 
     it('should throw when trying claim and convert without approval with claimAndConvert', async () => {
         try {
-            await bancorNetwork.claimAndConvert(smartToken1QuickBuyPath, 10000, 1);
+            await bancorNetwork.claimAndConvert(smartToken1BuyPath, 10000, 1);
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -436,7 +430,7 @@ contract('BancorNetwork', accounts => {
         await converter1.setConversionWhitelist(whitelist.address);
 
         let balanceBeforeTransfer = await smartToken1.balanceOf.call(accounts[1]);
-        await bancorNetwork.convertFor(smartToken1QuickBuyPath, 10000, 1, accounts[1], { value: 10000 });
+        await bancorNetwork.convertFor(smartToken1BuyPath, 10000, 1, accounts[1], { value: 10000 });
         let balanceAfterTransfer = await smartToken1.balanceOf.call(accounts[1]);
         assert.isAbove(balanceAfterTransfer.toNumber(), balanceBeforeTransfer.toNumber(), 'amount transfered');
 
@@ -448,7 +442,7 @@ contract('BancorNetwork', accounts => {
         await converter1.setConversionWhitelist(whitelist.address);
 
         try {
-            await bancorNetwork.convertFor(smartToken1QuickBuyPath, 10000, 1, accounts[1], { value: 10000 });
+            await bancorNetwork.convertFor(smartToken1BuyPath, 10000, 1, accounts[1], { value: 10000 });
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -458,17 +452,17 @@ contract('BancorNetwork', accounts => {
     });
 
     it('verifies that getReturnByPath returns the correct amount for buying the smart token', async () => {
-        let returnByPath = (await bancorNetwork.getReturnByPath.call(smartToken1QuickBuyPath, 10000))[0];
+        let returnByPath = (await bancorNetwork.getReturnByPath.call(smartToken1BuyPath, 10000))[0];
         let balanceBeforeTransfer = await smartToken1.balanceOf.call(accounts[1]);
-        await bancorNetwork.convertFor(smartToken1QuickBuyPath, 10000, 1, accounts[1], { value: 10000 });
+        await bancorNetwork.convertFor(smartToken1BuyPath, 10000, 1, accounts[1], { value: 10000 });
         let balanceAfterTransfer = await smartToken1.balanceOf.call(accounts[1]);
         assert.equal(returnByPath, balanceAfterTransfer - balanceBeforeTransfer);
     });
 
     it('verifies that getReturnByPath returns the correct amount for buying the smart token through multiple converters', async () => {
-        let returnByPath = (await bancorNetwork.getReturnByPath.call(smartToken2QuickBuyPath, 10000))[0];
+        let returnByPath = (await bancorNetwork.getReturnByPath.call(smartToken2BuyPath, 10000))[0];
         let balanceBeforeTransfer = await smartToken2.balanceOf.call(accounts[1]);
-        await bancorNetwork.convertFor(smartToken2QuickBuyPath, 10000, 1, accounts[1], { value: 10000 });
+        await bancorNetwork.convertFor(smartToken2BuyPath, 10000, 1, accounts[1], { value: 10000 });
         let balanceAfterTransfer = await smartToken2.balanceOf.call(accounts[1]);
         assert.equal(returnByPath, balanceAfterTransfer - balanceBeforeTransfer);
     });
@@ -485,10 +479,10 @@ contract('BancorNetwork', accounts => {
     });
 
     it('verifies that getReturnByPath returns the correct amount for selling the smart token', async () => {
-        await converter1.quickConvert(smartToken1QuickBuyPath, 100, 1, { from: accounts[1], value: 100 });
-        let returnByPath = (await bancorNetwork.getReturnByPath.call(smartToken1QuickSellPath, 100))[0];
+        await converter1.quickConvert(smartToken1BuyPath, 100, 1, { from: accounts[1], value: 100 });
+        let returnByPath = (await bancorNetwork.getReturnByPath.call(smartToken1SellPath, 100))[0];
         let balanceBeforeTransfer = web3.eth.getBalance(accounts[1]);
-        let res = await converter1.quickConvert(smartToken1QuickSellPath, 100, 1, { from: accounts[1] });
+        let res = await converter1.quickConvert(smartToken1SellPath, 100, 1, { from: accounts[1] });
         let transaction = web3.eth.getTransaction(res.tx);
         let transactionCost = transaction.gasPrice.times(res.receipt.cumulativeGasUsed);
         let balanceAfterTransfer = web3.eth.getBalance(accounts[1]);
@@ -496,10 +490,10 @@ contract('BancorNetwork', accounts => {
     });
 
     it('verifies that getReturnByPath returns the correct amount for selling the smart token through multiple converters', async () => {
-        await converter2.quickConvert(smartToken2QuickBuyPath, 100, 1, { from: accounts[1], value: 100 });
-        let returnByPath = (await bancorNetwork.getReturnByPath.call(smartToken2QuickSellPath, 100))[0];
+        await converter2.quickConvert(smartToken2BuyPath, 100, 1, { from: accounts[1], value: 100 });
+        let returnByPath = (await bancorNetwork.getReturnByPath.call(smartToken2SellPath, 100))[0];
         let balanceBeforeTransfer = web3.eth.getBalance(accounts[1]);
-        let res = await converter2.quickConvert(smartToken2QuickSellPath, 100, 1, { from: accounts[1] });
+        let res = await converter2.quickConvert(smartToken2SellPath, 100, 1, { from: accounts[1] });
         let transaction = web3.eth.getTransaction(res.tx);
         let transactionCost = transaction.gasPrice.times(res.receipt.cumulativeGasUsed);
         let balanceAfterTransfer = web3.eth.getBalance(accounts[1]);
@@ -542,12 +536,12 @@ contract('BancorNetwork', accounts => {
     });
 
     it('should throw when attempting to get the return by path with invalid long path', async () => {
-        let longQuickBuyPath = [];
+        let longBuyPath = [];
         for (let i = 0; i < 103; ++i)
-            longQuickBuyPath.push(etherToken.address);
+            longBuyPath.push(etherToken.address);
 
         try {
-            await bancorNetwork.getReturnByPath.call(longQuickBuyPath, 1000);
+            await bancorNetwork.getReturnByPath.call(longBuyPath, 1000);
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -559,11 +553,11 @@ contract('BancorNetwork', accounts => {
         let prevBalance1 = await smartToken1.balanceOf.call(accounts[0]);
         let prevBalance2 = await smartToken2.balanceOf.call(accounts[0]);
         await smartToken2.transfer(bancorNetwork.address, 20000);
-        let smartTokenQuickBuyPathMultiple = [etherToken.address, smartToken1.address, smartToken1.address, smartToken2.address, smartToken2.address, 
+        let smartTokenBuyPathMultiple = [etherToken.address, smartToken1.address, smartToken1.address, smartToken2.address, smartToken2.address, 
             smartToken2.address, smartToken2.address, smartToken1.address,
             smartToken2.address, smartToken2.address, smartToken1.address];
 
-        await bancorNetwork.convertForMultiple(smartTokenQuickBuyPathMultiple, [0, 5, 8], [10000, 10000, 10000], [1, 1, 1], accounts[0], { from: accounts[0], value: 10000 });
+        await bancorNetwork.convertForMultiple(smartTokenBuyPathMultiple, [0, 5, 8], [10000, 10000, 10000], [1, 1, 1], accounts[0], { from: accounts[0], value: 10000 });
         
         let newBalance1 = await smartToken1.balanceOf.call(accounts[0]);
         let newBalance2 = await smartToken2.balanceOf.call(accounts[0]);
@@ -575,9 +569,9 @@ contract('BancorNetwork', accounts => {
     it('verifies multiple convertFor with a single path', async () => {
         let prevBalance = await smartToken1.balanceOf.call(accounts[0]);
         await smartToken2.transfer(bancorNetwork.address, 10000);
-        let smartTokenQuickBuyPathMultiple = [smartToken2.address, smartToken2.address, smartToken1.address];
+        let smartTokenBuyPathMultiple = [smartToken2.address, smartToken2.address, smartToken1.address];
 
-        await bancorNetwork.convertForMultiple(smartTokenQuickBuyPathMultiple, [0], [10000], [1], accounts[0]);
+        await bancorNetwork.convertForMultiple(smartTokenBuyPathMultiple, [0], [10000], [1], accounts[0]);
         
         let newBalance = await smartToken1.balanceOf.call(accounts[0]);;
 
@@ -586,10 +580,10 @@ contract('BancorNetwork', accounts => {
 
     it('verifies multiple convertFor with multiple paths that each of them starts with ether', async () => {
         let prevBalance = await smartToken2.balanceOf.call(accounts[1]);
-        let smartTokenQuickBuyPathMultiple = [etherToken.address, smartToken1.address, smartToken1.address, smartToken2.address, smartToken2.address, 
+        let smartTokenBuyPathMultiple = [etherToken.address, smartToken1.address, smartToken1.address, smartToken2.address, smartToken2.address, 
             etherToken.address, smartToken1.address, smartToken1.address, smartToken2.address, smartToken2.address];
 
-        await bancorNetwork.convertForMultiple(smartTokenQuickBuyPathMultiple, [0, 5], [10000, 10000], [1, 1], accounts[1], { from: accounts[1], value: 20000 });
+        await bancorNetwork.convertForMultiple(smartTokenBuyPathMultiple, [0, 5], [10000, 10000], [1, 1], accounts[1], { from: accounts[1], value: 20000 });
         
         let newBalance = await smartToken2.balanceOf.call(accounts[1]);
 
@@ -600,9 +594,9 @@ contract('BancorNetwork', accounts => {
         let prevTokenBalance = await smartToken2.balanceOf.call(accounts[0]);
         await smartToken2.transfer(bancorNetwork.address, 100000);
 
-        let smartTokenQuickSellPath = [smartToken2.address, smartToken2.address, smartToken1.address, smartToken1.address, etherToken.address];
+        let smartTokenSellPath = [smartToken2.address, smartToken2.address, smartToken1.address, smartToken1.address, etherToken.address];
         let prevETHBalance = web3.eth.getBalance(accounts[0]);
-        let res = await bancorNetwork.convertForMultiple(smartTokenQuickSellPath, [0], [100000], [1], accounts[0]);
+        let res = await bancorNetwork.convertForMultiple(smartTokenSellPath, [0], [100000], [1], accounts[0]);
 
         let newETHBalance = web3.eth.getBalance(accounts[0]);
         let newTokenBalance = await smartToken2.balanceOf.call(accounts[0]);
@@ -619,10 +613,10 @@ contract('BancorNetwork', accounts => {
         await smartToken2.transfer(bancorNetwork.address, 30000);
         let prevETHBalance = web3.eth.getBalance(accounts[0]);
         let prevToken1Balance = await smartToken1.balanceOf.call(accounts[0]);
-        let smartTokenQuickSellPath = [smartToken2.address, smartToken2.address, smartToken1.address, smartToken1.address, etherToken.address,
+        let smartTokenSellPath = [smartToken2.address, smartToken2.address, smartToken1.address, smartToken1.address, etherToken.address,
             smartToken2.address, smartToken2.address, smartToken1.address, smartToken1.address, etherToken.address,
             smartToken2.address, smartToken2.address, smartToken1.address];
-        let res = await bancorNetwork.convertForMultiple(smartTokenQuickSellPath, [0, 5, 10], [10000, 10000, 10000], [1, 1, 1], accounts[0]);
+        let res = await bancorNetwork.convertForMultiple(smartTokenSellPath, [0, 5, 10], [10000, 10000, 10000], [1, 1, 1], accounts[0]);
         let newETHBalance = web3.eth.getBalance(accounts[0]);
         let newToken1Balance = await smartToken1.balanceOf.call(accounts[0]);
         let newToken2Balance = await smartToken2.balanceOf.call(accounts[0]);
@@ -636,10 +630,10 @@ contract('BancorNetwork', accounts => {
     it('should throw when attempts to call multiple convertFor with too high ether value', async () => {
         try {
             let prevBalance = await smartToken2.balanceOf.call(accounts[1]);
-            let smartTokenQuickBuyPathMultiple = [etherToken.address, smartToken1.address, smartToken1.address, smartToken2.address, smartToken2.address, 
+            let smartTokenBuyPathMultiple = [etherToken.address, smartToken1.address, smartToken1.address, smartToken2.address, smartToken2.address, 
                 etherToken.address, smartToken1.address, smartToken1.address, smartToken2.address, smartToken2.address];
 
-            await bancorNetwork.convertForMultiple(smartTokenQuickBuyPathMultiple, [0, 5], [10000, 10000], [1, 1], accounts[1], { from: accounts[1], value: 20001 });
+            await bancorNetwork.convertForMultiple(smartTokenBuyPathMultiple, [0, 5], [10000, 10000], [1, 1], accounts[1], { from: accounts[1], value: 20001 });
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -651,8 +645,8 @@ contract('BancorNetwork', accounts => {
         try {
             await smartToken2.transfer(bancorNetwork.address, 10000);
 
-            let smartTokenQuickSellPath = [smartToken2.address, smartToken2.address, smartToken1.address, smartToken1.address, etherToken.address]
-            let res = await bancorNetwork.convertForMultiple(smartTokenQuickSellPath, [0, 4], [10000], [1], accounts[0]);
+            let smartTokenSellPath = [smartToken2.address, smartToken2.address, smartToken1.address, smartToken1.address, etherToken.address]
+            let res = await bancorNetwork.convertForMultiple(smartTokenSellPath, [0, 4], [10000], [1], accounts[0]);
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -662,8 +656,8 @@ contract('BancorNetwork', accounts => {
 
     it('should throw when attempts to call multiple convertFor with zero amount in the amounts array', async () => {
         try {
-            let smartTokenQuickSellPath = [smartToken2.address, smartToken2.address, smartToken1.address, smartToken1.address, etherToken.address]
-            let res = await bancorNetwork.convertForMultiple(smartTokenQuickSellPath, [0, 4], [0], [1], accounts[0]);
+            let smartTokenSellPath = [smartToken2.address, smartToken2.address, smartToken1.address, smartToken1.address, etherToken.address]
+            let res = await bancorNetwork.convertForMultiple(smartTokenSellPath, [0, 4], [0], [1], accounts[0]);
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -678,10 +672,10 @@ contract('BancorNetwork', accounts => {
         let maximumBlock = block + 100;
         let gasPrice = defaultGasPriceLimit;
 
-        let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1QuickBuyPath});
+        let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1BuyPath});
         let result = sign(soliditySha3, trustedAddress);
 
-        await converter1.quickConvertPrioritized(smartToken1QuickBuyPath, 100, 1, maximumBlock, result.v, result.r, result.s, { from: accounts[1], value: 100 });
+        await converter1.quickConvertPrioritized(smartToken1BuyPath, 100, 1, maximumBlock, result.v, result.r, result.s, { from: accounts[1], value: 100 });
         let newBalance = await smartToken1.balanceOf.call(accounts[1]);
         assert.isAbove(newBalance.toNumber(), prevBalance.toNumber(), "new balance isn't higher than previous balance");
     });
@@ -692,10 +686,10 @@ contract('BancorNetwork', accounts => {
             let maximumBlock = block + 100;
             let gasPrice = defaultGasPriceLimit;
 
-            let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1QuickBuyPath});
+            let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1BuyPath});
             let result = sign(soliditySha3, untrustedAddress);
 
-            await converter1.quickConvertPrioritized(smartToken1QuickBuyPath, 100, 1, maximumBlock, result.v, result.r, result.s, { from: accounts[1], value: 100 });
+            await converter1.quickConvertPrioritized(smartToken1BuyPath, 100, 1, maximumBlock, result.v, result.r, result.s, { from: accounts[1], value: 100 });
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -713,7 +707,7 @@ contract('BancorNetwork', accounts => {
             let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': wrongPath});
             let result = sign(soliditySha3, trustedAddress);
 
-            await converter1.quickConvertPrioritized(smartToken1QuickBuyPath, 100, 1, maximumBlock, result.v, result.r, result.s, { from: accounts[1], value: 100 });
+            await converter1.quickConvertPrioritized(smartToken1BuyPath, 100, 1, maximumBlock, result.v, result.r, result.s, { from: accounts[1], value: 100 });
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -727,10 +721,10 @@ contract('BancorNetwork', accounts => {
             let maximumBlock = block + 100;
             let gasPrice = defaultGasPriceLimit;
 
-            let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1QuickBuyPath});
+            let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1BuyPath});
             let result = sign(soliditySha3, trustedAddress);
 
-            await converter1.quickConvertPrioritized(smartToken1QuickBuyPath, 200, 1, maximumBlock, result.v, result.r, result.s, { from: accounts[1], value: 100 });
+            await converter1.quickConvertPrioritized(smartToken1BuyPath, 200, 1, maximumBlock, result.v, result.r, result.s, { from: accounts[1], value: 100 });
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -745,10 +739,10 @@ contract('BancorNetwork', accounts => {
             let wrongBlockNumber = maximumBlock + 100;
             let gasPrice = defaultGasPriceLimit;
 
-            let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1QuickBuyPath});
+            let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1BuyPath});
             let result = sign(soliditySha3, trustedAddress);
 
-            await converter1.quickConvertPrioritized(smartToken1QuickBuyPath, 100, 1, wrongBlockNumber, result.v, result.r, result.s, { from: accounts[1], value: 100 });
+            await converter1.quickConvertPrioritized(smartToken1BuyPath, 100, 1, wrongBlockNumber, result.v, result.r, result.s, { from: accounts[1], value: 100 });
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -763,10 +757,10 @@ contract('BancorNetwork', accounts => {
             let wrongBlockNumber = maximumBlock - 1;
             let gasPrice = defaultGasPriceLimit;
 
-            let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1QuickBuyPath});
+            let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1BuyPath});
             let result = sign(soliditySha3, trustedAddress);
 
-            await converter1.quickConvertPrioritized(smartToken1QuickBuyPath, 100, 1, wrongBlockNumber, result.v, result.r, result.s, { from: accounts[1], value: 100 });
+            await converter1.quickConvertPrioritized(smartToken1BuyPath, 100, 1, wrongBlockNumber, result.v, result.r, result.s, { from: accounts[1], value: 100 });
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -780,10 +774,10 @@ contract('BancorNetwork', accounts => {
             let maximumBlock = block + 100;
             let gasPrice = defaultGasPriceLimit - 1;
 
-            let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1QuickBuyPath});
+            let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1BuyPath});
             let result = sign(soliditySha3, trustedAddress);
 
-            await converter1.quickConvertPrioritized(smartToken1QuickBuyPath, 100, 1, maximumBlock, result.v, result.r, result.s, { from: accounts[1], value: 100 });
+            await converter1.quickConvertPrioritized(smartToken1BuyPath, 100, 1, maximumBlock, result.v, result.r, result.s, { from: accounts[1], value: 100 });
             assert(false, "didn't throw");
         }
         catch (error) {
@@ -797,10 +791,10 @@ contract('BancorNetwork', accounts => {
             let maximumBlock = block + 100;
             let gasPrice = defaultGasPriceLimit + 1;
 
-            let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1QuickBuyPath});
+            let soliditySha3 = web3Utils.soliditySha3(maximumBlock, gasPrice, accounts[1], converter1.address, 100, {'type': 'address', 'value': smartToken1BuyPath});
             let result = sign(soliditySha3, trustedAddress);
 
-            await converter1.quickConvertPrioritized(smartToken1QuickBuyPath, 100, 1, maximumBlock, result.v, result.r, result.s, { from: accounts[1], value: 100 });
+            await converter1.quickConvertPrioritized(smartToken1BuyPath, 100, 1, maximumBlock, result.v, result.r, result.s, { from: accounts[1], value: 100 });
             assert(false, "didn't throw");
         }
         catch (error) {


### PR DESCRIPTION
quickBuyPath along with all its helper functions have been removed from the newest converter version (0.11), the BancorConverterUpgrader has also been updated to reflect these changes, and all the tests have been updated to not use/test the quickBuyPath