### PR TITLE
fix for items mapping and contractNames array mismatch

### DIFF
--- a/solidity/contracts/utility/ContractRegistry.sol
+++ b/solidity/contracts/utility/ContractRegistry.sol
@@ -19,7 +19,6 @@ contract ContractRegistry is IContractRegistry, Owned, Utils, ContractIds {
     struct RegistryItem {
         address contractAddress;    // contract address
         uint256 nameIndex;          // index of the item in the list of contract names
-        bool isSet;                 // used to tell if the mapping element is defined
     }
 
     mapping (bytes32 => RegistryItem) private items;    // name -> RegistryItem mapping
@@ -68,17 +67,15 @@ contract ContractRegistry is IContractRegistry, Owned, Utils, ContractIds {
     {
         require(_contractName.length > 0); // validate input
 
-        // update the address in the registry
-        items[_contractName].contractAddress = _contractAddress;
-
-        if (!items[_contractName].isSet) {
-            // mark the item as set
-            items[_contractName].isSet = true;
+        if (items[_contractName].contractAddress == address(0)) {
             // add the contract name to the name list
             uint256 i = contractNames.push(bytes32ToString(_contractName));
             // update the item's index in the list
             items[_contractName].nameIndex = i - 1;
         }
+
+        // update the address in the registry
+        items[_contractName].contractAddress = _contractAddress;
 
         // dispatch the address update event
         emit AddressUpdate(_contractName, _contractAddress);
@@ -91,6 +88,7 @@ contract ContractRegistry is IContractRegistry, Owned, Utils, ContractIds {
     */
     function unregisterAddress(bytes32 _contractName) public ownerOnly {
         require(_contractName.length > 0); // validate input
+        require(items[_contractName].contractAddress != address(0));
 
         // remove the address from the registry
         items[_contractName].contractAddress = address(0);

--- a/solidity/test/ContractRegistry.js
+++ b/solidity/test/ContractRegistry.js
@@ -96,4 +96,34 @@ contract('ContractRegistry', accounts => {
         name = await contractRegistry.contractNames.call(2);
         assert.equal(name, contractName2);
     });
+
+    it('verifies that a registry item can be unregistered and reregistered properly', async () => {
+        let contractRegistry = await ContractRegistry.new();
+        
+        await contractRegistry.registerAddress(contractName1, accounts[1]);
+        await contractRegistry.registerAddress(contractName2, accounts[2]);
+
+        await contractRegistry.unregisterAddress(contractName1);
+        await contractRegistry.registerAddress(contractName1, accounts[1]);
+
+        // contractName2 is in first index after unregister and reregister
+        let cn2 = await contractRegistry.contractNames.call(1);
+        let cn1 = await contractRegistry.contractNames.call(2);
+
+        assert.equal(cn1, contractName1);
+        assert.equal(cn2, contractName2);
+    });
+
+    it('should throw when unregistering non registered address', async () => {
+        let contractRegistry = await ContractRegistry.new();
+
+        await contractRegistry.registerAddress(contractName1, accounts[1]);
+        try {
+            await contractRegistry.unregisterAddress(contractName2);
+            assert(false, "didn't throw");
+        }
+        catch (error) {
+            return utils.ensureException(error);
+        }
+    });
 });


### PR DESCRIPTION
Implemented the recommended fix for the small bug in the ContractRegistry and added two tests (one for each case)