### PR TITLE
Fix getReturnByPath to respect old converter implementations returning 32 bytes instead of 64 bytes

### DIFF
--- a/solidity/contracts/BancorNetwork.sol
+++ b/solidity/contracts/BancorNetwork.sol
@@ -504,14 +504,13 @@ contract BancorNetwork is IBancorNetwork, TokenHolder, ContractIds, FeatureIds {
         return (amount, fee);
     }
 
-    function converterGetReturn(address destination, bytes data) private returns(uint256 amount, uint256 fee) {
+    function converterGetReturn(address destination, bytes data) private view returns(uint256 amount, uint256 fee) {
         bytes memory ret = new bytes(64);
         bool success;
         assembly {
-            success := call(
+            success := staticcall(
                 div(mul(gas, 63), 64),
                 destination,
-                0,
                 add(data, 32),
                 mload(data),
                 add(ret, 32),

--- a/solidity/contracts/BancorNetwork.sol
+++ b/solidity/contracts/BancorNetwork.sol
@@ -509,7 +509,7 @@ contract BancorNetwork is IBancorNetwork, TokenHolder, ContractIds, FeatureIds {
         bool success;
         assembly {
             success := call(
-                sub(gas, 34710),
+                div(mul(gas, 63), 64),
                 destination,
                 0,
                 add(data, 32),


### PR DESCRIPTION
You can try this implementation here:
https://etherscan.io/address/0x24618ec3a496e576a65503a16afd3ccfcf613f96#readContract

Try to call `getReturnByPath` with arguments to test ETH => DAI:
```
["0xc0829421c1d260bd3cb3e0f06cfe2d52db2ce315", "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c", "0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c", "0xee01b3ab5f6728adc137be101d99c678938e6e72", "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359"]
```
```
1000000000000000000
```

Issue details:
- https://github.com/ethereum/solidity/issues/4116
- https://medium.com/@chris_77367/explaining-unexpected-reverts-starting-with-solidity-0-4-22-3ada6e82308c